### PR TITLE
Revert "Bump jacoco-maven-plugin from 0.8.6 to 0.8.7"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.7</version>
+				<version>0.8.6</version>
 				<executions>
 					<execution>
 						<goals>


### PR DESCRIPTION
Reverts smart-football-table/smart-football-table-logread#22 since it does not compile due to bintray's system shutdown